### PR TITLE
Update to templates to use foreground mode

### DIFF
--- a/cmd/gear/commands.go
+++ b/cmd/gear/commands.go
@@ -45,7 +45,6 @@ var (
 
 	start   bool
 	isolate bool
-	fork    bool
 	sockAct bool
 
 	keyPath   string
@@ -90,6 +89,7 @@ func Execute() {
 	gearCmd.PersistentFlags().StringVar(&(keyPath), "key-path", "", "Specify the directory containing the server private key and trusted client public keys")
 	gearCmd.PersistentFlags().StringVarP(&(conf.Docker.Socket), "docker-socket", "S", "unix:///var/run/docker.sock", "Set the docker socket to use")
 	gearCmd.PersistentFlags().BoolVar(&(config.SystemDockerFeatures.EnvironmentFile), "has-env-file", false, "(experimental) Use --env-file with Docker, requires master from Apr 1st")
+	gearCmd.PersistentFlags().BoolVar(&(config.SystemDockerFeatures.ForegroundRun), "has-foreground", false, "(experimental) Use --foreground with Docker, requires alexlarsson/forking-run")
 	gearCmd.PersistentFlags().StringVarP(&hostIp, "host-ip", "H", GuessHostIp(), "IP address to listen for traffic")
 	gearCmd.PersistentFlags().StringVar(&deploymentPath, "with", "", "Provide a deployment descriptor to operate on")
 
@@ -100,7 +100,6 @@ func Execute() {
 		Run:   deployContainers,
 	}
 	deployCmd.Flags().BoolVar(&isolate, "isolate", false, "Use an isolated container running as a user")
-	deployCmd.Flags().BoolVar(&fork, "fork", false, "Run the container in the foreground (experimental, requires docker branch alexlarsson/forking-run)")
 	gearCmd.AddCommand(deployCmd)
 
 	installImageCmd := &cobra.Command{
@@ -114,7 +113,6 @@ func Execute() {
 	installImageCmd.Flags().BoolVar(&start, "start", false, "Start the container immediately")
 	installImageCmd.Flags().BoolVar(&isolate, "isolate", false, "Use an isolated container running as a user")
 	installImageCmd.Flags().BoolVar(&sockAct, "socket-activated", false, "Use a socket-activated container (experimental, requires Docker branch)")
-	installImageCmd.Flags().BoolVar(&fork, "fork", false, "Run the container in the foreground (experimental, requires docker branch alexlarsson/forking-run)")
 	installImageCmd.Flags().StringVar(&environment.Path, "env-file", "", "Path to an environment file to load")
 	installImageCmd.Flags().StringVar(&environment.Description.Source, "env-url", "", "A url to download environment files from")
 	installImageCmd.Flags().StringVar((*string)(&environment.Description.Id), "env-id", "", "An optional identifier for the environment being set")
@@ -406,7 +404,6 @@ func deployContainers(cmd *cobra.Command, args []string) {
 					Id:      instance.Id,
 					Image:   instance.Image,
 					Isolate: isolate,
-					Fork:    fork,
 
 					Ports:        instance.Ports.PortPairs(),
 					NetworkLinks: instance.NetworkLinks(),
@@ -512,7 +509,6 @@ func installImage(cmd *cobra.Command, args []string) {
 					Image:            imageId,
 					Started:          start,
 					Isolate:          isolate,
-					Fork:             fork,
 					SocketActivation: sockAct,
 
 					Ports:        *portPairs.Get().(*containers.PortPairs),

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type DockerConfiguration struct {
 
 type DockerFeatures struct {
 	EnvironmentFile bool
+	ForegroundRun   bool
 }
 
 var SystemDockerFeatures = DockerFeatures{}

--- a/jobs/install_container.go
+++ b/jobs/install_container.go
@@ -61,9 +61,6 @@ type InstallContainerRequest struct {
 	// Should this container be run in an isolated fashion
 	// (separate user, permission changes)
 	Isolate bool
-	// Fork the container and run isolated (requires docker fork
-	// in docker)
-	Fork bool
 	// Should this container be run in a socket activated fashion
 	// Implies Isolated (separate user, permission changes,
 	// no port forwarding, socket activated).
@@ -238,12 +235,10 @@ func (req *InstallContainerRequest) Execute(resp JobResponse) {
 
 	var templateName string
 	switch {
-	case req.Isolate:
-		templateName = "ISOLATED"
-	case req.Fork:
-		templateName = "FORK"
 	case req.SocketActivation:
 		templateName = "SOCKETACTIVATED"
+	case config.SystemDockerFeatures.ForegroundRun:
+		templateName = "FOREGROUND"
 	default:
 		templateName = "SIMPLE"
 	}


### PR DESCRIPTION
When using Alex's experimental --foreground branch (for testing), you can pass
--has-foreground to 'gear daemon' to have it generate templates for foreground.
This removes the --fork option in the API - a server is either using straight
up docker images, or foreground mode.  Foreground mode will be the default
execution mode when upstream lands their run-in-context changes.

Also, volumes are now properly linked from containers via --volumes-from
