### PR TITLE
Add a deployment fixture for redis/go-martini app.

### DIFF
--- a/deployment/fixtures/redis_martini_deploy.json
+++ b/deployment/fixtures/redis_martini_deploy.json
@@ -1,0 +1,23 @@
+{
+  "Containers":[
+    {
+      "Name":"webapp",
+      "Count":1,
+      "Image":"mrunalp/redis-todo",
+      "PublicPorts":[
+        {"Internal":3000,"External":50000}
+      ],
+      "Links":[
+        {"To":"db"}
+      ]
+    },
+    {
+      "Name":"db",
+      "Count":1,
+      "Image":"mrunalp/fedora-redis",
+      "PublicPorts":[
+        {"Internal":6379}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Simple todo application to demonstrate linking.
