### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Starting a Docker image on a system for the first time may involve several slow 
 * Downloading the initial image
 * Starting the process
 
-Those steps may fail in unpredictable ways - for instance, the service may start but fail due to a configuration error and never begin listening.  A client cannot know for certain the cause of the failure (unless they've solved the Halting Problem), and so a wait is nondeterministic.  A download may stall for minutes or hours due to network unpredictability, or the local disk may run out of storage during the download and fail (due to other users of the system).
+Those steps may fail in unpredictable ways - for instance, the service may start but fail due to a configuration error and never begin listening.  A client cannot know for certain the cause of the failure, and so a wait is nondeterministic.  A download may stall for minutes or hours due to network unpredictability, or the local disk may run out of storage during the download and fail (due to other users of the system).
 
 The API forces the client to provide the following info up front:
 


### PR DESCRIPTION
Remove the Halting Problem reference.
IMHO the limitation of knowing the cause of failures is not related to the Halting Problem, and failures may occur due to other reasons besides the algorithm (e.g. network).
