### PR TITLE
Added -l option to contrib/build to skip go get and only use installed and vendored packages

### DIFF
--- a/contrib/build
+++ b/contrib/build
@@ -8,18 +8,21 @@ function usage() {
 	echo "-s builds with selinux enabled"
 	echo "-d builds/deploys systemd service with docker"
 	echo "-i builds with idler daemon"
+	echo "-l builds with vendored packages only (skips go get)"
 	exit 1
 }
 
 use_selinux=false
 handle_systemd=false
 build_idler=false
+skip_go_get=false
 
-while getopts "sdi" o; do
+while getopts "sdil" o; do
 	case "${o}" in
 		s) use_selinux=true;;
 		d) handle_systemd=true;;
 		i) build_idler=true;;
+		l) skip_go_get=true;;
 		*) usage;;
 	esac
 done
@@ -37,12 +40,14 @@ fi
 if $handle_systemd; then
 	docker build -rm -t ccoleman/geard $ORIG_GOPATH && sudo systemctl restart geard.service	
 else
-	echo "Downloading build dependencies"  
-	# these packages should not be vendored
-	echo " "
-	echo "Note: Packages downloaded by go get at this point may need to be vendored."
-	go get -v -d -tags "$tags" ./...
-	echo "..done"
+	if ! $skip_go_get; then
+		echo "Downloading build dependencies"  
+		# these packages should not be vendored
+		echo " "
+		echo "Note: Packages downloaded by go get at this point may need to be vendored."
+		go get -v -d -tags "$tags" ./...
+		echo "..done"
+	fi
   
 	echo "Building.."
 	go install -tags "$tags" github.com/openshift/geard/cmd/gear


### PR DESCRIPTION
This is useful when building RPM packages where network operations are not possible.
