### PR TITLE
Only use IPv4 address for network links for now

### DIFF
--- a/cmd/gear/support.go
+++ b/cmd/gear/support.go
@@ -226,9 +226,11 @@ func (resolver *addressResolver) ResolveIP(host string) (net.IP, error) {
 					}
 					for i := range addrs {
 						if ip, ok := addrs[i].(*net.IPNet); ok {
-							log.Printf("Using %v for %s", ip, host)
-							resolver.local = ip.IP
-							return resolver.local, nil
+							if ip.IP.To4() != nil {
+								log.Printf("Using %v for %s", ip, host)
+								resolver.local = ip.IP
+								return resolver.local, nil
+							}
 						}
 					}
 				}


### PR DESCRIPTION
The iptables generation code for links depends on IPv4 addresses, make
the ResolveIP method use only IPv4 addresses for now.
