### PR TITLE
Make gear init --post more resilient

### DIFF
--- a/cmd/gear/commands.go
+++ b/cmd/gear/commands.go
@@ -82,6 +82,7 @@ var (
 )
 
 func init() {
+	log.SetFlags(0)
 	defaultTransport.Set("http")
 }
 


### PR DESCRIPTION
Clean up logging statements, use a simpler wait structure, and make gear log
by default without dates.
