### PR TITLE
Make environment values passthrough

### DIFF
--- a/cmd/gear/commands.go
+++ b/cmd/gear/commands.go
@@ -87,7 +87,7 @@ func Execute() {
 	}
 	gearCmd.PersistentFlags().StringVar(&(keyPath), "key-path", "", "Specify the directory containing the server private key and trusted client public keys")
 	gearCmd.PersistentFlags().StringVarP(&(conf.Docker.Socket), "docker-socket", "S", "unix:///var/run/docker.sock", "Set the docker socket to use")
-	gearCmd.PersistentFlags().BoolVar(&(config.SystemDockerFeatures.EnvironmentFile), "has-env-file", false, "(experimental) Use --env-file with Docker, requires master from Apr 1st")
+	gearCmd.PersistentFlags().BoolVar(&(config.SystemDockerFeatures.EnvironmentFile), "has-env-file", true, "Use --env-file with Docker, set false if older than 0.11")
 	gearCmd.PersistentFlags().BoolVar(&(config.SystemDockerFeatures.ForegroundRun), "has-foreground", false, "(experimental) Use --foreground with Docker, requires alexlarsson/forking-run")
 	gearCmd.PersistentFlags().StringVar(&deploymentPath, "with", "", "Provide a deployment descriptor to operate on")
 	gearCmd.PersistentFlags().Var(&defaultTransport, "transport", "Specify an alternate mechanism to connect to the gear agent")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,9 @@
-package config
+package config_test
 
 import (
 	"testing"
+
+	. "github.com/openshift/geard/config"
 )
 
 type Config_Test struct{}

--- a/containers/environment.go
+++ b/containers/environment.go
@@ -31,21 +31,24 @@ func (e *Environment) Check() error {
 	return nil
 }
 
+var whiteSpaces = " \t"
+
 func (e *Environment) FromString(s string) (bool, error) {
 	pair := strings.SplitN(s, "=", 2)
 	if len(pair) != 2 {
 		return false, nil
 	}
 	second := pair[1]
-	if strings.HasPrefix(second, "\"") || strings.HasPrefix(second, "'") {
-		value, err := strconv.Unquote(second)
-		if err != nil {
-			return true, errors.New("The value for " + second + " is not valid: " + err.Error())
-		}
-		second = value
+
+	// trim the front of a variable, but nothing else
+	variable := strings.TrimLeft(pair[0], whiteSpaces)
+	if strings.ContainsAny(variable, whiteSpaces) {
+		return false, fmt.Errorf("variable '%s' has white spaces", variable)
 	}
-	e.Name = pair[0]
+
+	e.Name = variable
 	e.Value = second
+
 	return true, nil
 }
 

--- a/containers/environment_test.go
+++ b/containers/environment_test.go
@@ -1,0 +1,38 @@
+package containers_test
+
+import (
+	"testing"
+
+	. "github.com/openshift/geard/containers"
+)
+
+func TestReadEnvironment(t *testing.T) {
+	for _, v := range []envTest{
+		envTest{"A=B", "A", "B", true, nil},
+		envTest{"A=\"B\"", "A", "\"B\"", true, nil},
+	} {
+		v.assert(t)
+	}
+}
+
+type envTest struct {
+	source      string
+	key         string
+	value       string
+	success     bool
+	expectedErr error
+}
+
+func (e *envTest) assert(t *testing.T) {
+	env := Environment{}
+	ok, err := env.FromString(e.source)
+	if ok != e.success {
+		t.Errorf("Expected '%s' to return %b, %v", e.source, e.success, err)
+	}
+	if e.key != env.Name {
+		t.Errorf("Expected key %s to equal %s", env.Name, e.key)
+	}
+	if e.value != env.Value {
+		t.Errorf("Expected value %s to equal %s", env.Value, e.value)
+	}
+}

--- a/deployment/fixtures/simple.env
+++ b/deployment/fixtures/simple.env
@@ -1,3 +1,4 @@
 TEST=value
 OTHER=1
 QUOTED="foo"
+IGNORED

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -353,7 +353,7 @@ func (s *IntegrationTestSuite) TestSimpleInstallAndStartImage(c *chk.C) {
 	c.Assert(strings.Contains(string(data), "Loaded: loaded (/var/lib/containers/units/In/ctr-IntTest000.service; enabled)"), chk.Equals, true)
 }
 
-var hasEnvFile = flag.Bool("env-file", false, "Test env-file feature")
+var hasEnvFile = flag.Bool("env-file", true, "Test env-file feature")
 
 func (s *IntegrationTestSuite) TestSimpleInstallWithEnv(c *chk.C) {
 	if !*hasEnvFile {
@@ -378,7 +378,8 @@ func (s *IntegrationTestSuite) TestSimpleInstallWithEnv(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Log(string(data))
 	c.Assert(strings.Contains(string(data), "TEST=\"value\""), chk.Equals, true)
-	c.Assert(strings.Contains(string(data), "QUOTED=\"foo\""), chk.Equals, true)
+	c.Assert(strings.Contains(string(data), "QUOTED=\"\\\"foo\\\"\""), chk.Equals, true)
+	c.Assert(strings.Contains(string(data), "IGNORED"), chk.Equals, false)
 }
 
 func (s *IntegrationTestSuite) TestIsolateInstallAndStartImage(c *chk.C) {


### PR DESCRIPTION
Enable --has-env-file by default now that Docker is 0.11
