### PR TITLE
Added 'version' command to sti,gear and switchns

### DIFF
--- a/cmd/gear/commands.go
+++ b/cmd/gear/commands.go
@@ -4,13 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	gcmd "github.com/openshift/geard/cmd"
-	"github.com/openshift/geard/config"
-	"github.com/openshift/geard/containers"
-	cjobs "github.com/openshift/geard/containers/jobs"
-	"github.com/openshift/geard/deployment"
-	"github.com/openshift/geard/dispatcher"
-	"github.com/spf13/cobra"
 	"io"
 	"io/ioutil"
 	"log"
@@ -19,6 +12,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+
+	gcmd "github.com/openshift/geard/cmd"
+	"github.com/openshift/geard/config"
+	"github.com/openshift/geard/containers"
+	cjobs "github.com/openshift/geard/containers/jobs"
+	"github.com/openshift/geard/deployment"
+	"github.com/openshift/geard/dispatcher"
+	"github.com/spf13/cobra"
 	// "github.com/openshift/geard/encrypted"
 	"github.com/openshift/geard/http"
 	"github.com/openshift/geard/jobs"
@@ -39,8 +40,8 @@ var (
 	keyPath   string
 	expiresAt int64
 
-	environment    gcmd.EnvironmentDescription
-	portPairs      gcmd.PortPairs
+	environment  gcmd.EnvironmentDescription
+	portPairs    gcmd.PortPairs
 	networkLinks = gcmd.NetworkLinks{}
 
 	gitKeys     bool
@@ -59,6 +60,8 @@ var (
 	listenAddr string
 
 	defaultTransport LocalTransportFlag
+
+	version string
 )
 
 var conf = http.HttpConfiguration{
@@ -77,6 +80,7 @@ func init() {
 
 // Parse the command line arguments and invoke one of the support subcommands.
 func Execute() {
+
 	gearCmd := &cobra.Command{
 		Use:   "gear",
 		Short: "Gear(d) is a tool for installing Docker containers to systemd",
@@ -237,6 +241,17 @@ func Execute() {
 	// }
 	// createTokenCmd.Flags().Int64Var(&expiresAt, "expires-at", time.Now().Unix()+3600, "Specify the content request token expiration time in seconds after the Unix epoch")
 	// gearCmd.gcmd.AddCommand(createTokenCmd)
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display version",
+		Long:  "Display version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("gear %s\n", version)
+		},
+	}
+
+	gearCmd.AddCommand(versionCmd)
 
 	gcmd.ExtendCommands(gearCmd, true)
 

--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -1,17 +1,19 @@
 package main
 
 import (
-	"log"
-	_ "net/http/pprof"
-
 	"errors"
 	"fmt"
-	"github.com/openshift/geard/sti"
-	"github.com/spf13/cobra"
 	"io/ioutil"
+	"log"
+	_ "net/http/pprof"
 	"os"
 	"strings"
+
+	"github.com/openshift/geard/sti"
+	"github.com/spf13/cobra"
 )
+
+var version string
 
 func parseEnvs(envStr string) (map[string]string, error) {
 	if envStr == "" {
@@ -55,6 +57,17 @@ func Execute() {
 	}
 	stiCmd.PersistentFlags().StringVarP(&(req.DockerSocket), "url", "U", "unix:///var/run/docker.sock", "Set the url of the docker socket to use")
 	stiCmd.PersistentFlags().BoolVar(&(req.Verbose), "verbose", false, "Enable verbose output")
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display version",
+		Long:  "Display version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("sti %s\n", version)
+		},
+	}
+
+	stiCmd.AddCommand(versionCmd)
 
 	buildCmd := &cobra.Command{
 		Use:   "build SOURCE BUILD_IMAGE APP_IMAGE_TAG",

--- a/cmd/switchns/main.go
+++ b/cmd/switchns/main.go
@@ -36,6 +36,7 @@ var (
 	gitRo           bool
 	envs            Environment
 	passthroughArgs []string
+	version         string
 )
 
 func main() {
@@ -53,6 +54,17 @@ func main() {
 	commandArgs, passthroughArgs = extractPassthroughArgs()
 
 	switchnsCmd.SetArgs(commandArgs)
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display version",
+		Long:  "Display version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("swtichns %s\n", version)
+		},
+	}
+
+	switchnsCmd.AddCommand(versionCmd)
 
 	if err := switchnsCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/contrib/build
+++ b/contrib/build
@@ -2,6 +2,7 @@
 
 source "$(dirname $0)/build-support"
 
+
 function usage() {
   echo "build [-s] [-d|-g] [-i] [-n]"
   echo "-s builds with selinux enabled"
@@ -54,6 +55,8 @@ function build_local() {
   local cc_message=" (target: $GOOS)"
 
   local build_success=true
+
+  local version="version $(git describe --abbrev=0 --tags), build $(git rev-parse --short HEAD)"
   for artifact in ${artifacts[@]}; do
     echo ""
     echo "------------------------------------------"
@@ -64,7 +67,7 @@ function build_local() {
       local flags=("-N -l")
     fi
 
-    if ! go install -gcflags "${flags[@]:-}" -tags "$tags" "github.com/openshift/geard/${artifact}"; then
+    if ! go install -ldflags "-X main.version '$version'" -gcflags "${flags[@]:-}" -tags "$tags" "github.com/openshift/geard/${artifact}"; then
       echo -e "\n===> FAILED"
       build_success=false
     else
@@ -132,6 +135,7 @@ fi
 if $build_idler; then
   tags="$tags idler"
 fi
+
 
 # Perform the build
 if $handle_systemd; then


### PR DESCRIPTION
The 'version' string is common for all command line components and the format should be same as docker use:

```
→ sti --version
sti version alpha3, build 178db29
```

The 'alpha3' is the latest 'git tag' and the build is current HEAD short ref.
