### PR TITLE
STI - return exit code 1 for failures

### DIFF
--- a/cmd/sti/main.go
+++ b/cmd/sti/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	_ "net/http/pprof"
 	"os"
@@ -93,20 +92,10 @@ func Execute() {
 			envs, _ := parseEnvs(envString)
 			buildReq.Environment = envs
 
-			if buildReq.WorkingDir == "tempdir" {
-				var err error
-				buildReq.WorkingDir, err = ioutil.TempDir("", "sti")
-				if err != nil {
-					fmt.Println(err.Error())
-					return
-				}
-				defer os.Remove(buildReq.WorkingDir)
-			}
-
 			res, err := sti.Build(buildReq)
 			if err != nil {
 				fmt.Printf("An error occured: %s\n", err.Error())
-				return
+				os.Exit(1)
 			}
 
 			for _, message := range res.Messages {
@@ -145,20 +134,10 @@ func Execute() {
 			envs, _ := parseEnvs(envString)
 			buildReq.Environment = envs
 
-			if buildReq.WorkingDir == "tempdir" {
-				var err error
-				buildReq.WorkingDir, err = ioutil.TempDir("", "sti")
-				if err != nil {
-					fmt.Println(err.Error())
-					return
-				}
-				defer os.Remove(buildReq.WorkingDir)
-			}
-
 			res, err := sti.Usage(buildReq)
 			if err != nil {
 				fmt.Printf("An error occured: %s\n", err.Error())
-				return
+				os.Exit(1)
 			}
 
 			for _, message := range res.Messages {

--- a/sti/build.go
+++ b/sti/build.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -142,6 +143,14 @@ fi
 `))
 
 func (h requestHandler) build(req BuildRequest) (*BuildResult, error) {
+	if req.WorkingDir == "tempdir" {
+		var err error
+		req.WorkingDir, err = ioutil.TempDir("", "sti")
+		if err != nil {
+			return nil, fmt.Errorf("Error creating temporary directory '%s': %s\n", req.WorkingDir, err.Error())
+		}
+		defer os.Remove(req.WorkingDir)
+	}
 
 	workingTmpDir := filepath.Join(req.WorkingDir, "tmp")
 	dirs := []string{"tmp", "scripts", "defaultScripts"}
@@ -212,6 +221,14 @@ func (h requestHandler) build(req BuildRequest) (*BuildResult, error) {
 }
 
 func (h requestHandler) usage(req BuildRequest) (*BuildResult, error) {
+	if req.WorkingDir == "tempdir" {
+		var err error
+		req.WorkingDir, err = ioutil.TempDir("", "sti")
+		if err != nil {
+			return nil, fmt.Errorf("Error creating temporary directory '%s': %s\n", req.WorkingDir, err.Error())
+		}
+		defer os.Remove(req.WorkingDir)
+	}
 
 	dirs := []string{"scripts", "defaultScripts"}
 	for _, v := range dirs {


### PR DESCRIPTION
Return exit code 1 if any error is encountered during build or usage.

Move creation of temporary directory from STI main down into the build
and usage functions.

Fixes #135 
