### PR TITLE
Create required container-active.target.wants directory on init.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,19 @@ func SetContainerBasePath(value string) error {
 	return nil
 }
 
+func SystemdBasePath() string {
+	return systemdBasePath
+}
+
+func SetSystemdBasePath(value string) error {
+	if "" == value {
+		return fmt.Errorf("SetSystemdBasePath: requires a non-empty argument")
+	}
+
+	systemdBasePath = value
+	return nil
+}
+
 type DockerConfiguration struct {
 	Socket string
 }
@@ -49,4 +62,5 @@ var (
 	SystemDockerFeatures = DockerFeatures{}
 	basePath             = "/var/lib/containers"
 	runPath              = "/var/run/containers"
+	systemdBasePath      = "/etc/systemd/system"
 )

--- a/containers/jobs/extend.go
+++ b/containers/jobs/extend.go
@@ -50,4 +50,8 @@ func init() {
 		filepath.Join(config.ContainerBasePath(), "ports", "descriptions"),
 		filepath.Join(config.ContainerBasePath(), "ports", "interfaces"),
 	)
+	config.AddRequiredDirectory(
+		0755,
+		filepath.Join(config.SystemdBasePath(), "container-active.target.wants"),
+	)
 }


### PR DESCRIPTION
It is removed on purge and leads to failures afterwards it not present.
