### PR TITLE
Don't force quoting on environment write.

### DIFF
--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -11,3 +11,24 @@ func TestGenerateId(t *testing.T) {
 		t.Error("Expected generated ID to be non empty")
 	}
 }
+
+func TestExtractVariablesFrom_NoAppend(t *testing.T) {
+	args := []string{"arg1", "a=b", "arg2", "c=d"}
+
+	env := EnvironmentDescription{}
+
+	if err := env.ExtractVariablesFrom(&args, false); err != nil {
+		t.Error("Unexpected error parsing arguments")
+	}
+
+	if len(env.Description.Variables) != 2 {
+		t.Error("Too few parsed arguments")
+	}
+
+	if env.Description.Variables[0].Name != "a" &&
+		env.Description.Variables[0].Value != "b" &&
+		env.Description.Variables[1].Name != "c" &&
+		env.Description.Variables[1].Value != "d" {
+		t.Error("Incorrect argument parsing")
+	}
+}

--- a/containers/environment.go
+++ b/containers/environment.go
@@ -38,7 +38,6 @@ func (e *Environment) FromString(s string) (bool, error) {
 	if len(pair) != 2 {
 		return false, nil
 	}
-	second := pair[1]
 
 	// trim the front of a variable, but nothing else
 	variable := strings.TrimLeft(pair[0], whiteSpaces)
@@ -46,8 +45,16 @@ func (e *Environment) FromString(s string) (bool, error) {
 		return false, fmt.Errorf("variable '%s' has white spaces", variable)
 	}
 
+	second, err := strconv.Unquote(pair[1])
+	if err != nil {
+		second = pair[1]
+	}
 	e.Name = variable
-	e.Value = second
+	e.Value = strings.TrimSpace(second)
+
+	if err := e.Check(); err != nil {
+		return false, err
+	}
 
 	return true, nil
 }
@@ -161,7 +168,7 @@ func (j *EnvironmentDescription) Write(appends bool) error {
 
 	env := j.Variables
 	for i := range env {
-		if _, errw := fmt.Fprintf(file, "%s=%s\n", env[i].Name, strconv.Quote(env[i].Value)); errw != nil {
+		if _, errw := fmt.Fprintf(file, "%s=%s\n", env[i].Name, env[i].Value); errw != nil {
 			log.Print("job_environment: Unable to write to environment file: ", err)
 			return err
 		}

--- a/containers/environment_test.go
+++ b/containers/environment_test.go
@@ -9,7 +9,13 @@ import (
 func TestReadEnvironment(t *testing.T) {
 	for _, v := range []envTest{
 		envTest{"A=B", "A", "B", true, nil},
-		envTest{"A=\"B\"", "A", "\"B\"", true, nil},
+		envTest{"A=\"B\"", "A", "B", true, nil},
+		envTest{"A='B'", "A", "B", true, nil},
+		envTest{"  A=B", "A", "B", true, nil},
+		envTest{"  A=B  ", "A", "B", true, nil},
+		envTest{"A=\"'B'\"", "A", "'B'", true, nil},
+		envTest{"A=\"'B  '\"", "A", "'B  '", true, nil},
+		envTest{"A=\"B  \"", "A", "B", true, nil},
 	} {
 		v.assert(t)
 	}
@@ -26,6 +32,9 @@ type envTest struct {
 func (e *envTest) assert(t *testing.T) {
 	env := Environment{}
 	ok, err := env.FromString(e.source)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
 	if ok != e.success {
 		t.Errorf("Expected '%s' to return %b, %v", e.source, e.success, err)
 	}

--- a/deployment/fixtures/simple.env
+++ b/deployment/fixtures/simple.env
@@ -1,4 +1,4 @@
 TEST=value
 OTHER=1
-QUOTED="foo"
+QUOTED=\"foo\"
 IGNORED

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -419,8 +419,8 @@ func (s *IntegrationTestSuite) TestSimpleInstallWithEnv(c *chk.C) {
 	data, err = cmd.CombinedOutput()
 	c.Assert(err, chk.IsNil)
 	c.Log(string(data))
-	c.Assert(strings.Contains(string(data), "TEST=\"value\""), chk.Equals, true)
-	c.Assert(strings.Contains(string(data), "QUOTED=\"\\\"foo\\\"\""), chk.Equals, true)
+	c.Assert(strings.Contains(string(data), "TEST=value"), chk.Equals, true)
+	c.Assert(strings.Contains(string(data), "QUOTED=\\\"foo\\\""), chk.Equals, true)
 	c.Assert(strings.Contains(string(data), "IGNORED"), chk.Equals, false)
 }
 


### PR DESCRIPTION
Updated @matthicksj PR

Docker's environment file will escape any quotes that exist, so
make sure not to quote environment values when writing them out.
Instead, just use line separation.

If you want quoted values in your environment file, you can double
quote the values and only the first wrapper will be removed.
