### PR TITLE
Switch to /bin/sh instead of bash.

### DIFF
--- a/cmd/switchns/main.go
+++ b/cmd/switchns/main.go
@@ -115,7 +115,7 @@ func switchnsExec(args []string) {
 			fmt.Printf("Couldn't get identifier from user: %v\n", u)
 			os.Exit(2)
 		}
-		runCommandInContainer(containerId.ContainerFor(), []string{"/bin/bash", "-l"}, []string{})
+		runCommandInContainer(containerId.ContainerFor(), []string{"/bin/sh", "-l"}, []string{})
 	}
 }
 


### PR DESCRIPTION
/bin/sh is more common and more importantly available on the busybox image that we use in the examples now.
