### PR TITLE
Switch STI test images to use 'busybox' instead of 'f20'

### DIFF
--- a/sti/test_images/sti-fake-broken/.sti/bin/run
+++ b/sti/test_images/sti-fake-broken/.sti/bin/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /sti-fake/run-invoked
 

--- a/sti/test_images/sti-fake-broken/.sti/bin/save-artifacts
+++ b/sti/test_images/sti-fake-broken/.sti/bin/save-artifacts
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /tmp/artifacts/save-artifacts-invoked

--- a/sti/test_images/sti-fake-broken/Dockerfile
+++ b/sti/test_images/sti-fake-broken/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM busybox
 RUN mkdir -p /sti-fake/src
 WORKDIR /
 ENV STI_SCRIPTS_URL https://raw.githubusercontent.com/openshift/geard/master/sti/test_images/sti-fake-broken/.sti/bin

--- a/sti/test_images/sti-fake-user/Dockerfile
+++ b/sti/test_images/sti-fake-user/Dockerfile
@@ -1,8 +1,8 @@
 FROM sti_test/sti-fake
 
 RUN mkdir -p /sti-fake && \
-    groupadd -r fakeuser -f -g 433 && \
-    useradd -u 431 -r -g fakeuser -d /sti-fake -s /sbin/nologin -c "Fake User" fakeuser && \
+    addgroup -g 433 fakeuser && \
+    adduser -D -u 431 -h /sti-fake -s /sbin/nologin fakeuser
     chown -R fakeuser:fakeuser /sti-fake
 
 USER fakeuser

--- a/sti/test_images/sti-fake/.sti/bin/assemble
+++ b/sti/test_images/sti-fake/.sti/bin/assemble
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cp -ad /tmp/src /sti-fake/
 touch /sti-fake/assemble-invoked

--- a/sti/test_images/sti-fake/.sti/bin/run
+++ b/sti/test_images/sti-fake/.sti/bin/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /sti-fake/run-invoked
 

--- a/sti/test_images/sti-fake/.sti/bin/save-artifacts
+++ b/sti/test_images/sti-fake/.sti/bin/save-artifacts
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /tmp/artifacts/save-artifacts-invoked

--- a/sti/test_images/sti-fake/Dockerfile
+++ b/sti/test_images/sti-fake/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM busybox
 RUN mkdir -p /sti-fake/src
 WORKDIR /
 ENV STI_SCRIPTS_URL https://raw.githubusercontent.com/openshift/geard/master/sti/test_images/sti-fake/.sti/bin


### PR DESCRIPTION
Note: The tests will fail atm, as STI will download the scripts from 'master' branch. This should be fixed in near future by providing simple HTTP server for script download.
