### PR TITLE
Various testing fixes

### DIFF
--- a/contrib/build
+++ b/contrib/build
@@ -33,7 +33,7 @@ function build_geard_service() {
 # Performs a local go install of geard.
 function build_local() {
   if ! $skip_go_get; then
-    echo "Downloading build dependencies"  
+    echo "Downloading build dependencies"
     # these packages should not be vendored
     echo " "
     echo "Note: Packages downloaded by go get at this point may need to be vendored."
@@ -62,7 +62,7 @@ function build_local() {
     echo "------------------------------------------"
     echo "Building ${artifact}${cc_message}..."
     echo "------------------------------------------"
-    
+
     if ! $enable_optimizations; then
       local flags=("-N -l")
     fi
@@ -74,7 +74,7 @@ function build_local() {
       echo -e "===> Success"
     fi
   done
-  
+
   if ! $build_success; then
     echo -e "\nExiting due to build failures." 1>&2
     exit 2

--- a/contrib/test
+++ b/contrib/test
@@ -17,6 +17,7 @@ setup_geard_build_env
 # Options parsing
 test_integration=false
 test_opts=""
+geard_home=$(cd `dirname $0`/..; pwd)
 
 while getopts "ao:" o; do
   case "${o}" in
@@ -32,26 +33,28 @@ echo "..done"
 
 rm -f tests.test
 
-go test $(find . -name *_test.go -printf "%h\n" | grep -v /vendor/ | grep -v /tests | xargs echo)
+pushd $geard_home >/dev/null
+  go test $(find . -name *_test.go -printf "%h\n" | grep -v /vendor/ | grep -v /tests | sort | uniq | xargs echo)
+popd >/dev/null
 
 if $test_integration; then
   echo "Building test images"
-  for image_dir in tests/images/*/; do
+  for image_dir in $geard_home/tests/images/*/; do
     pushd $image_dir >/dev/null
-    image_name=$(basename $image_dir)
-    echo " ---> $image_name"
-    docker build -t openshift/$image_name .
+      image_name=$(basename $image_dir)
+      echo " ---> $image_name"
+      docker build -t openshift/$image_name .
     popd >/dev/null
   done
 
   echo -e "\nRunning integration tests\n"
-  
+
   # build the sti images needed for the gear build integration tests
   echo -e "Building sti test images...."
-  pushd sti/test_images
-  ./buildimages.sh 
+  $geard_home/sti/test_images/buildimages.sh
   echo -e "done"
-  popd
   go test -tags integration -c github.com/openshift/geard/tests $test_opts
   sudo ./tests.test -gocheck.v $test_opts
+
+  go test github.com/openshift/geard/sti -integration
 fi

--- a/sti/contrib/test
+++ b/sti/contrib/test
@@ -14,6 +14,7 @@ function usage() {
 # Options parsing
 skip_build=false
 test_opts=""
+dir=$(dirname $0)
 
 while getopts "so:" o; do
   case "${o}" in
@@ -27,12 +28,12 @@ if $skip_build ; then
   echo "Skipping test image build"
 else
   echo "Building test images"
-  pushd ../test_images >/dev/null
+  pushd $dir/../test_images >/dev/null
   ./buildimages.sh
   popd >/dev/null
 fi
 
-pushd ../test_images &>/dev/null
+pushd $dir/../test_images &>/dev/null
 export STI_TEST_IMAGES_DIR=$(pwd)
 echo "Setting STI_TEST_IMAGES_DIR=${STI_TEST_IMAGES_DIR}"
 popd &>/dev/null

--- a/sti/test_images/buildimages.sh
+++ b/sti/test_images/buildimages.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
-pushd sti-fake
-docker build -t sti_test/sti-fake .
-cd ../sti-fake-user
-docker build -t sti_test/sti-fake-user .
-cd ../sti-fake-broken
-docker build -t sti_test/sti-fake-broken .
+dir=$(dirname $0)
+pushd $dir/sti-fake
+  docker build -t sti_test/sti-fake .
+popd
+
+pushd $dir/sti-fake-user
+  docker build -t sti_test/sti-fake-user .
+popd
+
+pushd $dir/sti-fake-broken
+  docker build -t sti_test/sti-fake-broken .
 popd

--- a/sti/test_images/sti-fake-broken/.sti/bin/run
+++ b/sti/test_images/sti-fake-broken/.sti/bin/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /sti-fake/run-invoked
 

--- a/sti/test_images/sti-fake-broken/.sti/bin/save-artifacts
+++ b/sti/test_images/sti-fake-broken/.sti/bin/save-artifacts
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /tmp/artifacts/save-artifacts-invoked

--- a/sti/test_images/sti-fake-broken/Dockerfile
+++ b/sti/test_images/sti-fake-broken/Dockerfile
@@ -1,4 +1,10 @@
-FROM fedora:20
+FROM busybox
 RUN mkdir -p /sti-fake/src
 WORKDIR /
-ENV STI_SCRIPTS_URL https://raw.githubusercontent.com/openshift/geard/master/sti/test_images/sti-fake-broken/.sti/bin
+
+# Need to serve the scripts from localhost so any potential changes to the
+# scripts are made available for integration testing.
+#
+# Port 23456 must match the port used in the http server in STI's
+# integration_test.go
+ENV STI_SCRIPTS_URL http://localhost:23456/sti-fake-broken/.sti/bin

--- a/sti/test_images/sti-fake-user/Dockerfile
+++ b/sti/test_images/sti-fake-user/Dockerfile
@@ -1,10 +1,7 @@
 FROM sti_test/sti-fake
 
 RUN mkdir -p /sti-fake && \
-    groupadd -r fakeuser -f -g 433 && \
-    useradd -u 431 -r -g fakeuser -d /sti-fake -s /sbin/nologin -c "Fake User" fakeuser && \
+    adduser -u 431 -h /sti-fake -s /sbin/nologin -D fakeuser && \
     chown -R fakeuser:fakeuser /sti-fake
 
 USER fakeuser
-ENV STI_SCRIPTS_URL https://raw.githubusercontent.com/openshift/geard/master/sti/test_images/sti-fake/.sti/bin
-                

--- a/sti/test_images/sti-fake/.sti/bin/assemble
+++ b/sti/test_images/sti-fake/.sti/bin/assemble
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cp -ad /tmp/src /sti-fake/
 touch /sti-fake/assemble-invoked

--- a/sti/test_images/sti-fake/.sti/bin/run
+++ b/sti/test_images/sti-fake/.sti/bin/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /sti-fake/run-invoked
 

--- a/sti/test_images/sti-fake/.sti/bin/save-artifacts
+++ b/sti/test_images/sti-fake/.sti/bin/save-artifacts
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 touch /tmp/artifacts/save-artifacts-invoked

--- a/sti/test_images/sti-fake/Dockerfile
+++ b/sti/test_images/sti-fake/Dockerfile
@@ -1,4 +1,10 @@
-FROM fedora:20
+FROM busybox
 RUN mkdir -p /sti-fake/src
 WORKDIR /
-ENV STI_SCRIPTS_URL https://raw.githubusercontent.com/openshift/geard/master/sti/test_images/sti-fake/.sti/bin
+
+# Need to serve the scripts from localhost so any potential changes to the
+# scripts are made available for integration testing.
+#
+# Port 23456 must match the port used in the http server in STI's
+# integration_test.go
+ENV STI_SCRIPTS_URL http://localhost:23456/sti-fake/.sti/bin

--- a/tests/build_test.go
+++ b/tests/build_test.go
@@ -4,8 +4,11 @@ package tests
 import (
 	"flag"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
+	"path"
+	"runtime"
 	"time"
 
 	"github.com/fsouza/go-dockerclient"
@@ -64,6 +67,17 @@ func (s *BuildIntegrationTestSuite) SetUpSuite(c *C) {
 	if s.daemonPort == "" {
 		s.daemonPort = "43273"
 	}
+
+	// get the full path to this .go file so we can get the correct path
+	// to the test_images directory
+	_, filename, _, _ := runtime.Caller(0)
+	testImagesDir := path.Join(path.Dir(filename), "..", "sti", "test_images")
+
+	// Need to serve the scripts from localhost so any potential changes to the
+	// scripts are made available for integration testing.
+	//
+	// Port 23456 must match the port used in the fake image Dockerfiles
+	go http.ListenAndServe(":23456", http.FileServer(http.Dir(testImagesDir)))
 }
 
 func (s *BuildIntegrationTestSuite) SetUpTest(c *C) {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -407,7 +409,11 @@ func (s *IntegrationTestSuite) TestSimpleInstallWithEnv(c *chk.C) {
 
 	hostContainerId := fmt.Sprintf("%v/%v", s.daemonURI, id)
 
-	cmd := exec.Command("/usr/bin/gear", "install", EnvImage, hostContainerId, "--env-file=deployment/fixtures/simple.env", "--start")
+	// get the full path to this .go file so we can get the correct path to the
+	// simple.env file
+	_, filename, _, _ := runtime.Caller(0)
+	envFile := path.Join(path.Dir(filename), "..", "deployment", "fixtures", "simple.env")
+	cmd := exec.Command("/usr/bin/gear", "install", EnvImage, hostContainerId, "--env-file="+envFile, "--start")
 	data, err := cmd.CombinedOutput()
 	c.Log(cmd.Args)
 	c.Log(string(data))


### PR DESCRIPTION
Convert STI test images to use busybox to minimize image size.

Change STI test image default script URLs to be served by localhost (and
start a local HTTP server in the integration tests) because otherwise
changes to STI that require corresponding changes to STI scripts can't
be tested before a git merge.

Update contrib/test to be runnable from anywhere.

Run STI integration tests from contrib/test.

Add closing of Reader used when downloading scripts.
