### PR TITLE
[DO NOT MERGE] Fix deletion of STI temp dir on exit

### DIFF
--- a/sti/build.go
+++ b/sti/build.go
@@ -66,7 +66,7 @@ func (h requestHandler) build(req BuildRequest) (*BuildResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error creating temporary directory '%s': %s\n", req.WorkingDir, err.Error())
 		}
-		defer os.Remove(req.WorkingDir)
+		defer RemoveDirectory(req.WorkingDir, h.verbose)
 	}
 
 	workingTmpDir := filepath.Join(req.WorkingDir, "tmp")

--- a/sti/templates.go
+++ b/sti/templates.go
@@ -4,19 +4,19 @@ import "text/template"
 
 // Script used to initialize permissions on bind-mounts when a non-root user is specified by an image
 var saveArtifactsInitTemplate = template.Must(template.New("sa-init.sh").Parse(`#!/bin/sh
-chown -R {{.User}}:{{.User}} /tmp/artifacts && chmod -R 755 /tmp/artifacts
-chown -R {{.User}}:{{.User}} /tmp/scripts && chmod -R 755 /tmp/scripts
-chown -R {{.User}}:{{.User}} /tmp/defaultScripts && chmod -R 755 /tmp/defaultScripts
-chown -R {{.User}}:{{.User}} /tmp/src && chmod -R 755 /tmp/src
+chown -R {{.User}} /tmp/artifacts && chmod -R 775 /tmp/artifacts
+chmod -R 755 /tmp/scripts
+chmod -R 755 /tmp/defaultScripts
+chmod -R 755 /tmp/src
 exec su {{.User}} - -s /bin/sh -c {{.SaveArtifactsPath}}
 `))
 
 // Script used to initialize permissions on bind-mounts for a docker-run build (prepare call)
 var buildTemplate = template.Must(template.New("build-init.sh").Parse(`#!/bin/sh
-{{if eq .Usage false }}chown -R {{.User}}:{{.User}} /tmp/src && chmod -R 755 /tmp/src{{end}}
-chown -R {{.User}}:{{.User}} /tmp/scripts && chmod -R 755 /tmp/scripts
-chown -R {{.User}}:{{.User}} /tmp/defaultScripts && chmod -R 755 /tmp/defaultScripts
-{{if .Incremental}}chown -R {{.User}}:{{.User}} /tmp/artifacts && chmod -R 755 /tmp/artifacts{{end}}
+{{if eq .Usage false }}chmod -R 755 /tmp/src{{end}}
+chmod -R 755 /tmp/scripts
+chmod -R 755 /tmp/defaultScripts
+{{if .Incremental}}chown -R {{.User}} /tmp/artifacts && chmod -R 775 /tmp/artifacts{{end}}
 mkdir -p /opt/sti/bin
 if [ -f {{.RunPath}} ]; then
 	cp {{.RunPath}} /opt/sti/bin
@@ -31,5 +31,4 @@ if [ -f {{.AssemblePath}} ]; then
 else
   echo "No assemble script supplied in ScriptsUrl argument, application source, or default url in the image."
 fi
-
 `))

--- a/sti/usage.go
+++ b/sti/usage.go
@@ -23,7 +23,7 @@ func Usage(req BuildRequest) (*BuildResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error creating temporary directory '%s': %s\n", req.WorkingDir, err.Error())
 		}
-		defer os.Remove(req.WorkingDir)
+		defer RemoveDirectory(req.WorkingDir, req.Verbose)
 	}
 
 	dirs := []string{"scripts", "defaultScripts"}

--- a/sti/util.go
+++ b/sti/util.go
@@ -221,3 +221,14 @@ func executeCallback(callbackUrl string, result *BuildResult) {
 		}
 	}
 }
+
+func RemoveDirectory(dir string, verbose bool) {
+	if verbose {
+		log.Printf("Removing directory '%s'\n", dir)
+	}
+
+	err := os.RemoveAll(dir)
+	if err != nil {
+		log.Printf("Error removing directory '%s': %s\n", dir, err.Error())
+	}
+}


### PR DESCRIPTION
Change call from os.Remove to os.RemoveAll to remove the temp dir and
its contents.

Only chown /tmp/artifacts.

Remove the chgrp portion of the chown calls as it shouldn't be necessary
and it keeps the user running sti from being able to delete the temp
dir.

Change /tmp/artifacts from 755 to 775 so it's group writable, meaning it
should be able to be deleted by the host user.

Fixes #164 
