### PR TITLE
Fix deletion of STI temp dir on exit

### DIFF
--- a/cmd/gear/commands.go
+++ b/cmd/gear/commands.go
@@ -50,7 +50,6 @@ var (
 
 	deploymentPath string
 
-	buildReq    sti.BuildRequest
 	keyFile     string
 	writeAccess bool
 	hostIp      string
@@ -63,6 +62,8 @@ var (
 
 	version string
 )
+
+var buildReq = &sti.STIRequest{}
 
 var conf = http.HttpConfiguration{
 	Dispatcher: &dispatcher.Dispatcher{
@@ -136,7 +137,6 @@ func Execute() {
 		Run:   buildImage,
 	}
 	buildCmd.Flags().BoolVar(&(buildReq.Clean), "clean", false, "Perform a clean build")
-	buildCmd.Flags().StringVar(&(buildReq.WorkingDir), "dir", "tempdir", "Directory where generated Dockerfiles and other support scripts are created")
 	buildCmd.Flags().StringVarP(&(buildReq.Ref), "ref", "r", "", "Specify a ref to check-out")
 	buildCmd.Flags().BoolVar(&(buildReq.Verbose), "verbose", false, "Enable verbose output")
 	buildCmd.Flags().StringVar(&(buildReq.CallbackUrl), "callbackUrl", "", "Specify a URL to invoke via HTTP POST upon build completion")
@@ -506,16 +506,6 @@ func buildImage(cmd *cobra.Command, args []string) {
 	buildReq.Writer = os.Stdout
 	buildReq.DockerSocket = conf.Docker.Socket
 	buildReq.Environment = environment.Description.Map()
-
-	if buildReq.WorkingDir == "tempdir" {
-		var err error
-		buildReq.WorkingDir, err = ioutil.TempDir("", "sti")
-		if err != nil {
-			fmt.Println(err.Error())
-			return
-		}
-		defer os.Remove(buildReq.WorkingDir)
-	}
 
 	res, err := sti.Build(buildReq)
 	if err != nil {

--- a/sti/README.md
+++ b/sti/README.md
@@ -117,11 +117,11 @@ Building a Deployable Image
     Available Flags:
          --callbackUrl="": Specify a URL to invoke via HTTP POST upon build completion
          --clean=false: Perform a clean build
-         --dir="tempdir": Directory where generated Dockerfiles and other support scripts are created
      -e, --env="": Specify an environment var NAME=VALUE,NAME2=VALUE2,...
      -r, --ref="": Specify a ref to check-out
-     -s, --scripts="": Specify a URL for the assemble, run, and save-artifacts scripts
-     -R, --runtime="": Set the runtime image to use
+         --rm=false: Remove the previous image during incremental builds
+         --savetempdir=false: Save the temporary directory used by STI instead of deleting it
+     -s, --scripts="": Specify a URL for the assemble and run scripts
      -U, --url="unix:///var/run/docker.sock": Set the url of the docker socket to use
          --verbose=false: Enable verbose output
 

--- a/sti/templates.go
+++ b/sti/templates.go
@@ -4,32 +4,29 @@ import "text/template"
 
 // Script used to initialize permissions on bind-mounts when a non-root user is specified by an image
 var saveArtifactsInitTemplate = template.Must(template.New("sa-init.sh").Parse(`#!/bin/sh
-chown -R {{.User}}:{{.User}} /tmp/artifacts && chmod -R 755 /tmp/artifacts
-chown -R {{.User}}:{{.User}} /tmp/scripts && chmod -R 755 /tmp/scripts
-chown -R {{.User}}:{{.User}} /tmp/defaultScripts && chmod -R 755 /tmp/defaultScripts
-chown -R {{.User}}:{{.User}} /tmp/src && chmod -R 755 /tmp/src
+chown -R {{.User}} /tmp/artifacts && chmod -R 775 /tmp/artifacts
+chmod -R 755 /tmp/scripts
+chmod -R 755 /tmp/defaultScripts
+chmod -R 755 /tmp/src
 exec su {{.User}} - -s /bin/sh -c {{.SaveArtifactsPath}}
 `))
 
 // Script used to initialize permissions on bind-mounts for a docker-run build (prepare call)
 var buildTemplate = template.Must(template.New("build-init.sh").Parse(`#!/bin/sh
-{{if eq .Usage false }}chown -R {{.User}}:{{.User}} /tmp/src && chmod -R 755 /tmp/src{{end}}
-chown -R {{.User}}:{{.User}} /tmp/scripts && chmod -R 755 /tmp/scripts
-chown -R {{.User}}:{{.User}} /tmp/defaultScripts && chmod -R 755 /tmp/defaultScripts
-{{if .Incremental}}chown -R {{.User}}:{{.User}} /tmp/artifacts && chmod -R 755 /tmp/artifacts{{end}}
+{{if eq .Usage false }}chown -R {{.User}} /tmp/src && chmod -R 775 /tmp/src{{end}}
+chmod -R 755 /tmp/scripts
+chmod -R 755 /tmp/defaultScripts
+{{if .Incremental}}chown -R {{.User}} /tmp/artifacts && chmod -R 775 /tmp/artifacts{{end}}
 mkdir -p /opt/sti/bin
+{{if .RunPath}}
 if [ -f {{.RunPath}} ]; then
 	cp {{.RunPath}} /opt/sti/bin
 fi
+{{end}}
 
 if [ -f {{.AssemblePath}} ]; then
-	{{if .Usage}}
-		exec su {{.User}} - -s /bin/sh -c "{{.AssemblePath}} -h"
-	{{else}}
-		exec su {{.User}} - -s /bin/sh -c {{.AssemblePath}}
-	{{end}}
+	exec su {{.User}} - -s /bin/sh -c "{{.AssemblePath}} {{if .Usage}}-h{{end}}"
 else
   echo "No assemble script supplied in ScriptsUrl argument, application source, or default url in the image."
 fi
-
 `))

--- a/sti/test_images/sti-fake-user/Dockerfile
+++ b/sti/test_images/sti-fake-user/Dockerfile
@@ -2,6 +2,6 @@ FROM sti_test/sti-fake
 
 RUN mkdir -p /sti-fake && \
     adduser -u 431 -h /sti-fake -s /sbin/nologin -D fakeuser && \
-    chown -R fakeuser:fakeuser /sti-fake
+    chown -R fakeuser /sti-fake
 
 USER fakeuser

--- a/sti/test_images/sti-fake/.sti/bin/assemble
+++ b/sti/test_images/sti-fake/.sti/bin/assemble
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cp -ad /tmp/src /sti-fake/
+cp -Rf /tmp/src /sti-fake/
 touch /sti-fake/assemble-invoked
 
 if [ -e /tmp/artifacts/save-artifacts-invoked ]; then

--- a/sti/usage.go
+++ b/sti/usage.go
@@ -1,8 +1,7 @@
 package sti
 
 import (
-	"fmt"
-	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -11,42 +10,45 @@ import (
 // Usage processes a build request by starting the container and executing
 // the assemble script with a "-h" argument to print usage information
 // for the script.
-func Usage(req BuildRequest) (*BuildResult, error) {
-	h, err := newHandler(req.Request)
+func Usage(req *STIRequest) error {
+	h, err := newHandler(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if req.WorkingDir == "tempdir" {
-		var err error
-		req.WorkingDir, err = ioutil.TempDir("", "sti")
-		if err != nil {
-			return nil, fmt.Errorf("Error creating temporary directory '%s': %s\n", req.WorkingDir, err.Error())
-		}
-		defer os.Remove(req.WorkingDir)
+	h.request.workingDir, err = createWorkingDirectory()
+	if err != nil {
+		return err
+	}
+	if h.request.PreserveWorkingDir {
+		log.Printf("Temporary directory '%s' will be saved, not deleted\n", h.request.workingDir)
+	} else {
+		defer removeDirectory(h.request.workingDir, h.request.Verbose)
 	}
 
 	dirs := []string{"scripts", "defaultScripts"}
 	for _, v := range dirs {
-		err := os.Mkdir(filepath.Join(req.WorkingDir, v), 0700)
+		err := os.Mkdir(filepath.Join(h.request.workingDir, v), 0700)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	if req.ScriptsUrl != "" {
 		url, _ := url.Parse(req.ScriptsUrl + "/" + "assemble")
-		downloadFile(url, req.WorkingDir+"/scripts/assemble", h.verbose)
+		downloadFile(url, h.request.workingDir+"/scripts/assemble", h.request.Verbose)
 	}
 
-	defaultUrl, err := h.getDefaultUrl(req, req.BaseImage)
+	defaultUrl, err := h.getDefaultUrl()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if defaultUrl != "" {
 		url, _ := url.Parse(defaultUrl + "/" + "assemble")
-		downloadFile(url, req.WorkingDir+"/defaultScripts/assemble", h.verbose)
+		downloadFile(url, h.request.workingDir+"/defaultScripts/assemble", h.request.Verbose)
 	}
 
-	return h.buildDeployableImage(req, req.BaseImage, req.WorkingDir, false)
+	h.request.usage = true
+	_, _, err = h.buildInternal()
+	return err
 }

--- a/sti/util.go
+++ b/sti/util.go
@@ -184,7 +184,7 @@ func imageHasEntryPoint(image *docker.Image) bool {
 	return found
 }
 
-func executeCallback(callbackUrl string, result *BuildResult) {
+func executeCallback(callbackUrl string, result *STIResult) {
 	buf := new(bytes.Buffer)
 	writer := bufio.NewWriter(buf)
 	for _, message := range result.Messages {
@@ -220,4 +220,24 @@ func executeCallback(callbackUrl string, result *BuildResult) {
 			break
 		}
 	}
+}
+
+func removeDirectory(dir string, verbose bool) {
+	if verbose {
+		log.Printf("Removing directory '%s'\n", dir)
+	}
+
+	err := os.RemoveAll(dir)
+	if err != nil {
+		log.Printf("Error removing directory '%s': %s\n", dir, err.Error())
+	}
+}
+
+func createWorkingDirectory() (directory string, err error) {
+	directory, err = ioutil.TempDir("", "sti")
+	if err != nil {
+		return "", fmt.Errorf("Error creating temporary directory '%s': %s\n", directory, err.Error())
+	}
+
+	return directory, err
 }


### PR DESCRIPTION
Code cleanup/refactoring.

Change call from os.Remove to os.RemoveAll to remove the temp dir and
its contents.

Only chown /tmp/artifacts.

Remove the chgrp portion of the chown calls as it shouldn't be necessary
and it keeps the user running sti from being able to delete the temp
dir.

Change /tmp/artifacts from 755 to 775 so it's group writable, meaning it
should be able to be deleted by the host user.

Fix issue where the build would fail when trying to determine the
default scripts URL if the image didn't already exist locally.

Fixes #164
