### PR TITLE
fix bug where list-units ignores units of container with a dot in the name

### DIFF
--- a/containers/identifier.go
+++ b/containers/identifier.go
@@ -16,10 +16,11 @@ import (
 
 type Identifier string
 
-var InvalidIdentifier = Identifier("")
-var allowedIdentifier = regexp.MustCompile("\\A[a-zA-Z0-9\\-\\.]{4,24}\\z")
-
 const IdentifierPrefix = "ctr-"
+const IdentifierSuffixPattern = "[a-zA-Z0-9\\-\\.]{4,24}"
+
+var InvalidIdentifier = Identifier("")
+var allowedIdentifier = regexp.MustCompile("\\A" + IdentifierSuffixPattern + "\\z")
 
 func NewIdentifier(s string) (Identifier, error) {
 	switch {

--- a/containers/jobs/linux/list_units.go
+++ b/containers/jobs/linux/list_units.go
@@ -66,7 +66,8 @@ func unitsMatching(conn systemd.Systemd, includeInactive bool, re *regexp.Regexp
 	return nil
 }
 
-var reContainerUnits = regexp.MustCompile("\\A" + regexp.QuoteMeta(containers.IdentifierPrefix) + "([^\\.]+)\\.service\\z")
+var reContainerUnits = regexp.MustCompile("\\A" + regexp.QuoteMeta(containers.IdentifierPrefix) + "(" + containers.IdentifierSuffixPattern + ")\\.service\\z")
+
 
 type listContainers struct {
 	*ListContainersRequest


### PR DESCRIPTION
this is related to https://github.com/openshift/geard/issues/173 and solves a bug in `gear list-units` where a containers installed like this:

`gear install openshift/busybox-http-app app.4` wouldn't be listed in `gear list-units -a` because it has a dot in the name.

I moved the container identifier pattern to a constant that can be references in other places to avoid this situation in the future.
