### PR TITLE
Create group before creating container user.

### DIFF
--- a/containers/systemd/init/templates.go
+++ b/containers/systemd/init/templates.go
@@ -21,6 +21,7 @@ type ContainerInitScript struct {
 var ContainerInitTemplate = template.Must(template.New("container-init.sh").Parse(`#!/bin/sh
 {{ if .CreateUser }}
 if command -v useradd >/dev/null; then
+	groupadd -g {{.Gid}} {{.ContainerUser}}
 	useradd -u {{.Uid}} -g {{.Gid}} {{.ContainerUser}}
 else
 	adduser -u {{.Uid}} -g {{.Gid}} {{.ContainerUser}}


### PR DESCRIPTION
This is a bit tricky as creating a group before creating a user doesn't work on busybox, but potentially breaks other images e.g. pmorie/sti-html-app. The fix solves the non-busybox case https://github.com/openshift/geard/issues/202