### PR TITLE
Suppress verbose messages from port allocation by default

### DIFF
--- a/port/allocation.go
+++ b/port/allocation.go
@@ -33,7 +33,8 @@ func NewPortAllocator(base string, min, max Port) *PortAllocator {
 //
 func (a *PortAllocator) allocatePort() Port {
 	p := <-a.ports
-	log.Printf("ports: Reserved port %d", p)
+
+	//log.Printf("ports: Reserved port %d", p)
 	return p
 }
 
@@ -69,7 +70,8 @@ func (p *PortAllocator) findPorts() {
 		} else {
 			p.block += 1
 		}
-		log.Printf("ports: searching block %d, %d-%d", p.block, start, end-1)
+
+		//log.Printf("ports: searching block %d, %d-%d", p.block, start, end-1)
 
 		var taken []string
 		parent, _ := p.portPathsFor(start)


### PR DESCRIPTION
This will suppress the 'ports' message during `gear list-units`:

```
[root@dev vagrant]# gear list-units
ports: searching block 41, 4000-4099
ID                   SERVER  ACTIVE  SUB     LOAD    TYPE

```

You can turn the messages on just by exporting the 'GEARD_VERBOSE' environment variable. @smarterclayton -> do you think we can use that ENV var on more places, to turn off the debug messages? 
