### PR TITLE
Add support for setting env vars in deployment JSON

### DIFF
--- a/containers/cmd/cmd.go
+++ b/containers/cmd/cmd.go
@@ -288,12 +288,14 @@ func (ctx *CommandContext) deployContainers(c *cobra.Command, args []string) {
 		Serial: func(on cmd.Locator) cmd.JobRequest {
 			instance, _ := changes.Instances.Find(cloc.AsIdentifier(on))
 			links := instance.NetworkLinks()
+
 			return &cjobs.InstallContainerRequest{
 				RequestIdentifier: jobs.NewRequestIdentifier(),
 
-				Id:      instance.Id,
-				Image:   instance.Image,
-				Isolate: ctx.isolate,
+				Id:          instance.Id,
+				Image:       instance.Image,
+				Environment: instance.EnvironmentVariables(),
+				Isolate:     ctx.isolate,
 
 				Ports:        instance.Ports.PortPairs(),
 				NetworkLinks: &links,

--- a/containers/environment.go
+++ b/containers/environment.go
@@ -61,6 +61,14 @@ func (e *Environment) FromString(s string) (bool, error) {
 
 type EnvironmentVariables []Environment
 
+func ToArray(v map[string]string) EnvironmentVariables {
+	env := make(EnvironmentVariables, 0, len(v))
+	for name := range v {
+		env = append(env, Environment{name, v[name]})
+	}
+	return env
+}
+
 func ExtractEnvironmentVariablesFrom(existing *[]string) (EnvironmentVariables, error) {
 	args := *existing
 	unchanged := make([]string, 0, len(args))
@@ -206,12 +214,12 @@ func (j *EnvironmentDescription) ReadFrom(r io.Reader) error {
 		return err
 	}
 
-	env := make(EnvironmentVariables, 0, len(all))
-	for name := range all {
-		e := Environment{name, all[name]}
-		env = append(env, e)
+	j.Variables = ToArray(all)
+
+	if err := j.Check(); err != nil {
+		return err
 	}
-	j.Variables = env
+
 	return nil
 }
 

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -208,10 +208,11 @@ func (d *Deployment) createInstances(c *Container) error {
 			return err
 		}
 		instance := &Instance{
-			Id:    id,
-			From:  c.Name,
-			Image: c.Image,
-			Ports: newPortMappings(c.PublicPorts),
+			Id:          id,
+			From:        c.Name,
+			Image:       c.Image,
+			Ports:       newPortMappings(c.PublicPorts),
+			Environment: c.Environment,
 
 			container: c,
 			add:       true,
@@ -248,8 +249,9 @@ func (d *Deployment) UpdateLinks() {
 type Container struct {
 	Name        string
 	Image       string
-	PublicPorts port.PortPairs `json:"PublicPorts,omitempty"`
-	Links       Links          `json:"Links,omitempty"`
+	PublicPorts port.PortPairs                  `json:"PublicPorts,omitempty"`
+	Links       Links                           `json:"Links,omitempty"`
+	Environment containers.EnvironmentVariables `json:",omitempty"`
 
 	Count    int
 	Affinity string `json:"Affinity,omitempty"`

--- a/deployment/instance.go
+++ b/deployment/instance.go
@@ -21,6 +21,9 @@ type Instance struct {
 	// The mapping of internal, external, and remote ports
 	Ports PortMappings `json:"Ports,omitempty"`
 
+	// Extra environment variables set for the instance
+	Environment containers.EnvironmentVariables `json:",omitempty"`
+
 	// Was this instance added.
 	add bool
 	// Is this instance flagged for removal
@@ -42,6 +45,10 @@ func (i *Instance) NetworkLinks() containers.NetworkLinks {
 	return i.links.NetworkLinks()
 }
 
+func (i *Instance) EnvironmentVariables() *containers.EnvironmentDescription {
+	return &containers.EnvironmentDescription{Id: i.Id, Variables: i.Environment}
+}
+
 func (i *Instance) Added() bool {
 	return i.add
 }
@@ -60,9 +67,6 @@ func (i *Instance) ResolveHostname() (string, error) {
 		return "", errors.New(fmt.Sprintf("No locator available for this instance (can't resolve from %s)", i.On))
 	}
 	return i.on.ResolveHostname()
-}
-
-func (i *Instance) EnvironmentVariables() {
 }
 
 func (instances Instances) Find(id containers.Identifier) (*Instance, bool) {


### PR DESCRIPTION
This will add support for defining environment variables that are passed into containers in deployment JSON. The main reason I made this is that when you are deploying eg. wordpress + mysql, then you have to set the MYSQL_PASS for the `mysql` image. Then on `mysql` run, this ENV var is passed into the mysql server.

Next use case is Docker registry, you have to pass couple env vars to configure it properly. While you can do it already using the `--env-file` option, there is no such option for the `deploy`.

```
{
    "IdPrefix": "simple-",
    "containers": [
        {
            "name": "test",
            "count": 1,
            "image": "openshift/busybox-http-app",
            "env": {
                "FOO": "bar",
                "MYSQL_PASS": "secret"
            }
        }
    ]
}
```

`$ gear deploy simple.json`

Then:

```
$ cat /var/lib/containers/env/contents/si/simple-test-1
FOO=bar
MYSQL_PASS=secret
```
