### PR TITLE
[origin_cartridge_200]Met "panic: runtime error: invalid memory address or nil pointer dereference" when sti/gear build with -s option

### DIFF
--- a/sti/util.go
+++ b/sti/util.go
@@ -124,6 +124,10 @@ func tarDirectory(dir string) (*os.File, error) {
 func downloadFile(url *url.URL, targetFile string, verbose bool) error {
 	sr := schemeReaders[url.Scheme]
 
+	if sr == nil {
+		log.Printf("ERROR: No URL handler found for url %s", url.String())
+		return fmt.Errorf("ERROR: No URL handler found for url %s", url.String())
+	}
 	reader, err := sr(url)
 	if err != nil {
 		log.Printf("ERROR: Reading error while downloading %s (%s)\n", url.String(), err)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1105469
