### PR TITLE
Bug 1118597 - Do not exit if the extra STI script download failed

### DIFF
--- a/sti/build.go
+++ b/sti/build.go
@@ -397,7 +397,7 @@ func (h requestHandler) downloadScripts() error {
 	//
 	wg.Wait()
 	if errorCount > 0 {
-		return ErrScriptsDownloadFailed
+		log.Printf("WARNING: %d STI scripts failed to download properly.\n", errorCount)
 	}
 
 	targetSourceDir := filepath.Join(h.request.workingDir, "src")


### PR DESCRIPTION
If we fail to download some script (like when users are overriding the default STI_SCRIPTS_URL with --scripts), then we should not fail the build when we have all required scripts already downloaded. It might be useful to just tell users that "some" of the scripts failed to download, which means it build will probably not pick up the script they supplied by --scripts.