### PR TITLE
Fix possible data race in geard deployment test

### DIFF
--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -447,9 +447,11 @@ func TestNewDeploymentFromURL_Secure(t *testing.T) {
 }
 
 func TestNewDeploymentFromURL_Timeout(t *testing.T) {
+	done := make(chan struct{})
 	server := httptest.NewTLSServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
 		time.Sleep(2 * time.Second)
 		w.Write([]byte("{}"))
+		close(done)
 	}))
 	defer server.Close()
 
@@ -464,4 +466,5 @@ func TestNewDeploymentFromURL_Timeout(t *testing.T) {
 		t.Errorf("TestDeployment_NewDeploymentFromURL_Timeout: Expected timeout err, not: %v", err)
 
 	}
+	<-done
 }


### PR DESCRIPTION
Fixes the following data race found by `go test -race`:

```
WARNING: DATA RACE
Write by goroutine 28:
  sync.raceWrite()
      /usr/lib/golang/src/pkg/sync/race.go:41 +0x35
  sync.(*WaitGroup).Wait()
      /usr/lib/golang/src/pkg/sync/waitgroup.go:120 +0x16d
  net/http/httptest.(*Server).Close()
      /usr/lib/golang/src/pkg/net/http/httptest/server.go:168 +0x6a
  github.com/openshift/geard/deployment.TestNewDeploymentFromURL_Timeout()
      /data/src/github.com/openshift/geard/deployment/deployment_test.go:467 +0x1a5
  testing.tRunner()
      /usr/lib/golang/src/pkg/testing/testing.go:391 +0x10f

Previous read by goroutine 32:
  sync.raceRead()
      /usr/lib/golang/src/pkg/sync/race.go:37 +0x35
  sync.(*WaitGroup).Add()
      /usr/lib/golang/src/pkg/sync/waitgroup.go:60 +0xc1
  net/http/httptest.(*waitGroupHandler).ServeHTTP()
      /usr/lib/golang/src/pkg/net/http/httptest/server.go:198 +0x5e
  net/http.serverHandler.ServeHTTP()
      /usr/lib/golang/src/pkg/net/http/server.go:1597 +0x1ca
  net/http.(*conn).serve()
      /usr/lib/golang/src/pkg/net/http/server.go:1167 +0xc00
```

[test]
